### PR TITLE
Show the channels on the Glimesh.tv homepage

### DIFF
--- a/lib/blocs/repos/channel_list_bloc.dart
+++ b/lib/blocs/repos/channel_list_bloc.dart
@@ -32,6 +32,14 @@ class LoadMyLiveFollowedChannels extends ChannelListEvent {
   List<Object> get props => [];
 }
 
+class LoadHomepageChannels extends ChannelListEvent {
+  @override
+  String toString() => 'LoadHomepageChannels';
+
+  @override
+  List<Object> get props => [];
+}
+
 @immutable
 abstract class ChannelListState extends Equatable {
   ChannelListState([List props = const []]) : super();
@@ -82,6 +90,8 @@ class ChannelListBloc extends Bloc<ChannelListEvent, ChannelListState> {
         yield* _loadChannels(event.categorySlug, event.channelLimit);
       } else if (event is LoadMyLiveFollowedChannels) {
         yield* _loadMyLiveFollowedChannels();
+      } else if (event is LoadHomepageChannels) {
+        yield* _loadHomepageChannels();
       } else {
         // New event, who dis?
       }
@@ -141,6 +151,35 @@ class ChannelListBloc extends Bloc<ChannelListEvent, ChannelListState> {
       yield ChannelListLoaded(results: listOfChannels);
     } catch (error) {
       print(error);
+      yield ChannelListNotLoaded();
+    }
+  }
+
+  Stream<ChannelListState> _loadHomepageChannels() async* {
+    try {
+      yield ChannelListLoading();
+
+      final queryResults = await this.glimeshRepository.getHomepageChannels();
+
+      if (queryResults.hasException) {
+        yield ChannelListNotLoaded(queryResults.exception!.graphqlErrors);
+        return;
+      }
+
+      final List<dynamic> channels =
+          queryResults.data!['homepageChannels']['edges'] as List<dynamic>;
+
+      // filter and then map here because channels can stop streaming and still be on the homepage,
+      // and this seemed like the best way instead of introducing nulls elsewhere.
+      final List<Channel> listOfChannels = channels
+          .where((c) => c['node']['stream'] != null)
+          .map(buildChannelFromJson)
+          .toList();
+
+      yield ChannelListLoaded(results: listOfChannels);
+    } catch (error, s) {
+      print(error);
+      print(s);
       yield ChannelListNotLoaded();
     }
   }

--- a/lib/graphql/queries/channels.dart
+++ b/lib/graphql/queries/channels.dart
@@ -66,3 +66,36 @@ query GetMyself {
   }
 }
 ''';
+
+const String queryHomepageChannels = r'''
+query GetHomepageChannels {
+  homepageChannels{
+    edges {
+      node {
+        id
+        title
+        chatBgUrl
+        language
+        matureContent
+
+        stream {
+          thumbnailUrl
+        }
+
+        subcategory {
+          name
+        }
+
+        tags {
+          name
+        }
+
+        streamer {
+          username
+          avatarUrl
+        }
+      }
+    }
+  }
+}
+''';

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -36,6 +36,11 @@ class GlimeshRepository {
         document: parseString(channel_queries.queryLiveFollowedChannels)));
   }
 
+  Future<QueryResult> getHomepageChannels() async {
+    return client.query(QueryOptions(
+        document: parseString(channel_queries.queryHomepageChannels)));
+  }
+
   Future<QueryResult> getSomeChatMessages(int channelId) {
     return client.query(QueryOptions(
       document: parseString(chat_queries.getSomeChatMessages),

--- a/lib/screens/AppScreen.dart
+++ b/lib/screens/AppScreen.dart
@@ -37,7 +37,7 @@ class _AppScreenState extends State<AppScreen> {
     setState(() {
       pages = [
         ProfileScreen(client: widget.client),
-        CategoryListScreen(),
+        CategoryListScreen(client: widget.client),
         FollowingScreen(client: widget.client),
       ];
       _selectedIndex = 1;

--- a/lib/screens/CategoryListScreen.dart
+++ b/lib/screens/CategoryListScreen.dart
@@ -220,7 +220,6 @@ class CategoryListWidget extends StatelessWidget {
                 }
 
                 return ListView.builder(
-                  //scrollDirection: Axis.vertical,
                   shrinkWrap: true,
                   primary: false,
                   itemCount: channels.length,

--- a/lib/screens/CategoryListScreen.dart
+++ b/lib/screens/CategoryListScreen.dart
@@ -1,11 +1,24 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:glimesh_app/models.dart';
+import 'package:glimesh_app/blocs/repos/channel_list_bloc.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:glimesh_app/repository.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
 
 class CategoryListScreen extends StatelessWidget {
+  final GraphQLClient client;
+
+  const CategoryListScreen({required this.client}) : super();
+
   @override
   Widget build(BuildContext context) {
-    return CategoryListWidget();
+    return BlocProvider(
+      create: (context) => ChannelListBloc(
+        glimeshRepository: GlimeshRepository(client: client),
+      ),
+      child: CategoryListWidget(),
+    );
   }
 }
 

--- a/lib/screens/CategoryListScreen.dart
+++ b/lib/screens/CategoryListScreen.dart
@@ -190,4 +190,47 @@ class CategoryListWidget extends StatelessWidget {
       ),
     );
   }
+
+  Widget _buildCard(BuildContext context, Channel channel) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          height: 220.0,
+          child: Stack(
+            children: <Widget>[
+              Positioned.fill(
+                // In order to have the ink splash appear above the image, you
+                // must use Ink.image. This allows the image to be painted as part
+                // of the Material and display ink effects above it. Using a
+                // standard Image will obscure the ink splash.
+                child: Ink.image(
+                  image: NetworkImage(channel.thumbnail),
+                  fit: BoxFit.cover,
+                  child: Container(),
+                ),
+              ),
+              Positioned(
+                bottom: 16.0,
+                left: 16.0,
+                right: 16.0,
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(20.0),
+                      color: Colors.black54,
+                    ),
+                    padding: EdgeInsets.all(15),
+                    child: Text(channel.title),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/screens/CategoryListScreen.dart
+++ b/lib/screens/CategoryListScreen.dart
@@ -158,6 +158,9 @@ class CategoryListWidget extends StatelessWidget {
   }
 
   Widget _buildSomeStreams(BuildContext context) {
+    ChannelListBloc bloc = BlocProvider.of<ChannelListBloc>(context);
+    bloc.add(LoadHomepageChannels());
+
     return Container(
       padding: EdgeInsets.all(20),
       child: Column(


### PR DESCRIPTION
(per #10)

Now there's a query for the homepage channels, they can be shown in the app, I've put them below the "Explore Live Streams" header.

There's code to filter away any streams still on the homepage but offline but apart from that it just shows exactly what the main site does.

Here's a video, for demo's sake (on an iPhone X)

https://user-images.githubusercontent.com/16962286/134738859-35ad09eb-fbce-43de-8de0-b6e4c05f65ee.mov

*PS: I think it would be a good idea to look at renaming the file & class from `CategoryListScreen` to `BrowseScreen` and maybe we should also look at removing duplication of the `_buildStreams` function, the one here is copied from FollowingChannels which I think is the same as the category screen?*

