### PR TITLE
Profile Page

### DIFF
--- a/lib/blocs/repos/user_bloc.dart
+++ b/lib/blocs/repos/user_bloc.dart
@@ -118,6 +118,29 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     return User(
       id: int.parse(json['id']),
       username: json['username'] as String,
+      teamRole: json['teamRole'] as String?,
+      avatarUrl: json['avatarUrl'] as String,
+      countFollowers: json['countFollowers'] as int,
+      countFollowing: json['countFollowing'] as int,
+      profileContentMd: json['profileContentMd'] as String?,
+      socialDiscord: json['socialDiscord'] as String?,
+      socialGuilded: json['socialGuilded'] as String?,
+      socialYoutube: json['socialYoutube'] as String?,
+      socialInstagram: json['socialInstagram'] as String?,
+      socials: buildSocialsFromJson(json['socials']),
     );
+  }
+
+  List<Social> buildSocialsFromJson(dynamic json) {
+    List<Social> socials = [];
+
+    for (var js in json) {
+      socials.add(Social(
+        platform: js['platform'] as String,
+        username: js['username'] as String,
+      ));
+    }
+
+    return socials;
   }
 }

--- a/lib/blocs/repos/user_bloc.dart
+++ b/lib/blocs/repos/user_bloc.dart
@@ -18,12 +18,12 @@ class LoadMyself extends UserEvent {
 }
 
 class LoadUser extends UserEvent {
-  final int id;
+  final String username;
 
-  LoadUser({required this.id}) : super([id]);
+  LoadUser({required this.username}) : super([username]);
 
   @override
-  List<Object> get props => [this.id];
+  List<Object> get props => [this.username];
 }
 
 @immutable
@@ -65,7 +65,7 @@ class UserBloc extends Bloc<UserEvent, UserState> {
       if (event is LoadMyself) {
         yield* _mapMyselfToState();
       } else if (event is LoadUser) {
-        yield* _mapUserToState(event.id);
+        yield* _mapUserToState(event.username);
       } else {
         // New event, who dis?
       }
@@ -95,11 +95,11 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     }
   }
 
-  Stream<UserState> _mapUserToState(int userId) async* {
+  Stream<UserState> _mapUserToState(String userName) async* {
     try {
       yield UserLoading();
 
-      final queryResults = await this.glimeshRepository.getUser(userId);
+      final queryResults = await this.glimeshRepository.getUser(userName);
 
       if (queryResults.hasException) {
         yield UserNotLoaded(queryResults.exception!.graphqlErrors);

--- a/lib/graphql/queries/user.dart
+++ b/lib/graphql/queries/user.dart
@@ -3,6 +3,19 @@ query GetMyself {
   myself {
     id
     username
+	teamRole
+	avatarUrl
+	countFollowers
+	countFollowing
+	profileContentMd
+	socialDiscord
+	socialGuilded
+	socialYoutube
+	socialInstagram
+	socials {
+		platform
+		username
+	}
   }
 }
 ''';
@@ -12,6 +25,19 @@ query GetUser($username: String!) {
   user(username: $username) {
     id
     username
+	teamRole
+	avatarUrl
+	countFollowers
+	countFollowing
+	profileContentMd
+	socialDiscord
+	socialGuilded
+	socialYoutube
+	socialInstagram
+	socials {
+		platform
+		username
+	}
   }
 }
 ''';

--- a/lib/graphql/queries/user.dart
+++ b/lib/graphql/queries/user.dart
@@ -8,7 +8,7 @@ query GetMyself {
 ''';
 
 const String getUser = r'''
-query GetUser($userId: ID!) {
+query GetUser($userId: Int!) {
   user(id: $userId) {
     id
     username

--- a/lib/graphql/queries/user.dart
+++ b/lib/graphql/queries/user.dart
@@ -8,8 +8,8 @@ query GetMyself {
 ''';
 
 const String getUser = r'''
-query GetUser($userId: Int!) {
-  user(id: $userId) {
+query GetUser($username: String!) {
+  user(username: $username) {
     id
     username
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,8 +8,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:glimesh_app/screens/LoginScreen.dart';
 import 'package:glimesh_app/screens/ChannelListScreen.dart';
+import 'package:glimesh_app/screens/ProfileScreen.dart';
 import 'package:glimesh_app/auth.dart';
 import 'package:glimesh_app/blocs/repos/chat_messages_bloc.dart';
+import 'package:glimesh_app/blocs/repos/user_bloc.dart';
 import 'package:glimesh_app/screens/ChannelScreen.dart';
 import 'package:glimesh_app/models.dart';
 import 'package:glimesh_app/repository.dart';
@@ -98,6 +100,22 @@ class GlimeshApp extends StatelessWidget {
                     GlimeshRepository(client: authState!.client!),
               ),
               child: ChannelScreen(channel: channel),
+            );
+          },
+        );
+      }
+
+      if (settings.name == '/profile') {
+        final String username = settings.arguments as String;
+
+        return MaterialPageRoute(
+          builder: (context) {
+            return BlocProvider(
+              create: (context) => UserBloc(
+                glimeshRepository:
+                    GlimeshRepository(client: authState!.client!),
+              ),
+              child: UserProfileScreen(username: username),
             );
           },
         );

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,12 +1,42 @@
 import 'package:flutter/material.dart';
 
 class User {
-  const User({
+  User({
     required this.id,
     required this.username,
+    this.teamRole,
+    required this.avatarUrl,
+    required this.countFollowers,
+    required this.countFollowing,
+    this.profileContentMd,
+    this.socialDiscord,
+    this.socialGuilded,
+    this.socialYoutube,
+    this.socialInstagram,
+    required this.socials,
   });
 
   final int id;
+  final String username;
+  final String? teamRole;
+  final String avatarUrl;
+  final int countFollowers;
+  final int countFollowing;
+  final String? profileContentMd;
+  final String? socialDiscord;
+  final String? socialGuilded;
+  final String? socialYoutube;
+  final String? socialInstagram;
+  List<Social> socials;
+}
+
+class Social {
+  const Social({
+    required this.platform,
+    required this.username,
+  });
+
+  final String platform;
   final String username;
 }
 

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -17,10 +17,10 @@ class GlimeshRepository {
     ));
   }
 
-  Future<QueryResult> getUser(int userId) async {
+  Future<QueryResult> getUser(String userName) async {
     return client.query(QueryOptions(
       document: parseString(user_queries.getUser),
-      variables: <String, dynamic>{"userId": userId},
+      variables: <String, dynamic>{"username": userName},
     ));
   }
 

--- a/lib/screens/AppScreen.dart
+++ b/lib/screens/AppScreen.dart
@@ -36,7 +36,7 @@ class _AppScreenState extends State<AppScreen> {
 
     setState(() {
       pages = [
-        ProfileScreen(client: widget.client),
+        MyProfileScreen(client: widget.client),
         CategoryListScreen(client: widget.client),
         FollowingScreen(client: widget.client),
       ];

--- a/lib/screens/ProfileScreen.dart
+++ b/lib/screens/ProfileScreen.dart
@@ -170,7 +170,7 @@ class ProfileWidget extends StatelessWidget {
         if (social.platform == "twitter") {
           socials.add(IconButton(
               onPressed: () {
-                _openSocialLink("https://twitter.com/${social.username}");
+                _openLink("https://twitter.com/${social.username}");
               },
               icon: FaIcon(FontAwesomeIcons.twitter)));
         }
@@ -181,7 +181,7 @@ class ProfileWidget extends StatelessWidget {
       socials.add(
         IconButton(
             onPressed: () {
-              _openSocialLink("https://youtube.com/${user.socialYoutube}");
+              _openLink("https://youtube.com/${user.socialYoutube}");
             },
             icon: FaIcon(FontAwesomeIcons.youtube)),
       );
@@ -191,7 +191,7 @@ class ProfileWidget extends StatelessWidget {
       socials.add(
         IconButton(
             onPressed: () {
-              _openSocialLink("https://instagram.com/${user.socialInstagram}");
+              _openLink("https://instagram.com/${user.socialInstagram}");
             },
             icon: FaIcon(FontAwesomeIcons.instagram)),
       );
@@ -201,7 +201,7 @@ class ProfileWidget extends StatelessWidget {
       socials.add(
         IconButton(
             onPressed: () {
-              _openSocialLink(
+              _openLink(
                   "https://discord.com/invite/${user.socialDiscord}");
             },
             icon: FaIcon(FontAwesomeIcons.discord)),
@@ -212,7 +212,7 @@ class ProfileWidget extends StatelessWidget {
       socials.add(
         IconButton(
             onPressed: () {
-              _openSocialLink(user.socialGuilded!);
+              _openLink(user.socialGuilded!);
             },
             icon: FaIcon(FontAwesomeIcons.guilded)),
       );
@@ -221,7 +221,7 @@ class ProfileWidget extends StatelessWidget {
     return Row(children: socials, mainAxisAlignment: MainAxisAlignment.center);
   }
 
-  void _openSocialLink(String link) async => {
+  void _openLink(String link) async => {
         await canLaunch(link)
             ? await launch(link)
             : throw "failed to launch ${link}"

--- a/lib/screens/ProfileScreen.dart
+++ b/lib/screens/ProfileScreen.dart
@@ -5,10 +5,30 @@ import 'package:glimesh_app/models.dart';
 import 'package:glimesh_app/repository.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
-class ProfileScreen extends StatelessWidget {
+class UserProfileScreen extends StatelessWidget {
+  final String username;
+
+  const UserProfileScreen({required this.username}) : super();
+
+  @override
+  Widget build(BuildContext context) {
+    UserBloc bloc = BlocProvider.of<UserBloc>(context);
+    bloc.add(LoadUser(username: username));
+
+    return Scaffold(
+        appBar: AppBar(title: Text("Profile")),
+        body: BlocBuilder(
+            bloc: bloc,
+            builder: (BuildContext context, UserState state) {
+              return ProfileWidget(userState: state);
+            }));
+  }
+}
+
+class MyProfileScreen extends StatelessWidget {
   final GraphQLClient client;
 
-  const ProfileScreen({required this.client}) : super();
+  const MyProfileScreen({required this.client}) : super();
 
   @override
   Widget build(BuildContext context) {
@@ -17,44 +37,55 @@ class ProfileScreen extends StatelessWidget {
         create: (context) => UserBloc(
           glimeshRepository: GlimeshRepository(client: client),
         ),
-        child: ProfileWidget(),
+        child: _MyProfileWidget(),
       ),
     );
   }
 }
 
-class ProfileWidget extends StatelessWidget {
+// this is intentionally a bit hacky, but it works
+class _MyProfileWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     UserBloc bloc = BlocProvider.of<UserBloc>(context);
     bloc.add(LoadMyself());
 
     return BlocBuilder(
-      bloc: bloc,
-      builder: (BuildContext context, UserState state) {
-        if (state is UserLoading) {
-          return Container(
-            child: Center(
-              child: CircularProgressIndicator(
-                semanticsLabel: "Loading ...",
-              ),
-            ),
-          );
-        }
+        bloc: bloc,
+        builder: (BuildContext context, UserState state) {
+          return ProfileWidget(userState: state);
+        });
+  }
+}
 
-        if (state is UserNotLoaded) {
-          return Text("Error loading user");
-        }
-        if (state is UserLoaded) {
-          User user = state.user;
+class ProfileWidget extends StatelessWidget {
+  final UserState userState;
 
-          return Center(
-            child: Text("You are ${user.username} :)"),
-          );
-        }
+  const ProfileWidget({required this.userState}) : super();
 
-        return Text("Unexpected");
-      },
-    );
+  @override
+  Widget build(BuildContext context) {
+    if (userState is UserLoading) {
+      return Container(
+        child: Center(
+          child: CircularProgressIndicator(
+            semanticsLabel: "Loading ...",
+          ),
+        ),
+      );
+    }
+
+    if (userState is UserNotLoaded) {
+      return Text("Error loading user");
+    }
+    if (userState is UserLoaded) {
+      User user = (userState as UserLoaded).user;
+
+      return Center(
+        child: Text("${user.username} :)"),
+      );
+    }
+
+    return Text("Unexpected");
   }
 }

--- a/lib/screens/ProfileScreen.dart
+++ b/lib/screens/ProfileScreen.dart
@@ -6,6 +6,7 @@ import 'package:glimesh_app/repository.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 
 class UserProfileScreen extends StatelessWidget {
   final String username;
@@ -98,7 +99,8 @@ class ProfileWidget extends StatelessWidget {
   Widget _buildStacked(BuildContext context, User user) {
     return Column(children: [
       _buildProfileInfo(context, user),
-      Text(user.profileContentMd ?? "")
+      Padding(padding: EdgeInsets.only(bottom: 5)),
+      Expanded(child: Markdown(data: user.profileContentMd ?? "", onTapLink: _handleMarkdownLinkTap))
     ]);
   }
 
@@ -107,8 +109,12 @@ class ProfileWidget extends StatelessWidget {
         padding: EdgeInsets.all(20),
         child: Row(children: [
           Expanded(flex: 3, child: _buildProfileInfo(context, user)),
-          Expanded(flex: 9, child: Text(user.profileContentMd ?? "")),
+          Expanded(flex: 9, child: Markdown(data: user.profileContentMd ?? "", onTapLink: _handleMarkdownLinkTap)),
         ]));
+  }
+
+  void _handleMarkdownLinkTap(String _text, String? href, String _title) {
+	_openLink(href!);
   }
 
   Widget _buildProfileInfo(BuildContext context, User user) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -184,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.8"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.1.0"
   gql:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -167,6 +167,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.3.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.8"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -303,6 +310,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   shared_preferences: ^2.0.8
   sentry_flutter: ^6.0.1
   font_awesome_flutter: ^9.1.0
+  flutter_markdown: ^0.6.8
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   uni_links: ^0.5.1
   shared_preferences: ^2.0.8
   sentry_flutter: ^6.0.1
+  font_awesome_flutter: ^9.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
implements #6

This is still what I'd label as super early, but I need to get opinions on how it looks and if it's missing anything super important.

Currently, the only way to access it is by the profile tab at the bottom of the screen on the Browse page, as I'm debating where the best place on a Channel a "View Profile" button is? (For testing, i've got it next to the follow button, which is fine on tablets, but isn't on phones)

The social links work, I haven't implemented a thing like we have for linked Twitter accounts to differentiate them from unlinked accounts yet, but socials are shown.

Markdown Links work, images work, images that are also links work and images scale to the width of the container so there's no X scrolling, and scrolling down and up works.

(Ninja Edit):
There currently isn't a report button, although it has a space and is marked todo, I've not put it in yet because there's nothing in the API for it yet, same with pronouns, they have a space reserved, but no API yet

Here's a screenshot dump from an iPhone (folded up to save space):
<details>
<summary>GreyWalker</summary>

![Screen Shot 2021-10-25 at 21 05 57](https://user-images.githubusercontent.com/16962286/138766000-83fc1a50-2f2a-4355-91e0-52bbad0249bd.png)
</details>
<details>
<summary>Deseptus</summary>

![Screen Shot 2021-10-25 at 21 06 07](https://user-images.githubusercontent.com/16962286/138766014-b50b0d0a-de8d-47dd-9848-f2cf1fffcf8b.png)
</details>
<details>
<summary>Sleepyhead</summary>

![Screen Shot 2021-10-25 at 21 06 18](https://user-images.githubusercontent.com/16962286/138766032-fd5b5407-7cc0-4662-b7b3-c57c687ac35b.png)
</details>
<details>
<summary>FadedKamui</summary>

Their GIF works (not shown here)
![Screen Shot 2021-10-25 at 21 06 26](https://user-images.githubusercontent.com/16962286/138766206-9d226a82-ff50-42f5-a90d-b947073827ad.png)
</details>
<details>
<summary>Blitz</summary>

Blitz's profile here shown to display how I'm handling displaying the Team Role (which I've currently only implemented colours for GCT and Core, until we lock in how it'll look)
As a note, Blitz's profile renders no markdown, which stumped me for a bit, although running the query in Insomnia shows that he appears to be using HTML directly, which this library explicitly states isn't supported.
![Screen Shot 2021-10-25 at 21 08 30](https://user-images.githubusercontent.com/16962286/138766534-6366dda1-d0e5-4566-8f0e-25a325f947da.png)
</details>

And here's some from a Tablet:
<details>
<summary>Mine (Portrait)</summary>

![Screen Shot 2021-10-25 at 21 14 13](https://user-images.githubusercontent.com/16962286/138767762-d21bebc8-7339-4eed-8b13-d89547e82fe6.png)
</details>
<details>
<summary>Jokky (Portrait)</summary>

![Screen Shot 2021-10-25 at 21 14 58](https://user-images.githubusercontent.com/16962286/138767864-7bfdb72b-81de-4049-9d6e-82f44c1702fd.png)
</details>
<details>
<summary>Jokky (Landscape)</summary>

![Screen Shot 2021-10-25 at 21 15 03](https://user-images.githubusercontent.com/16962286/138767915-716f9863-208e-4209-9ac4-42ff43117c2a.png)
</details>
<details>
<summary>FadedKamui (Landscape)</summary>

![Screen Shot 2021-10-25 at 21 15 40](https://user-images.githubusercontent.com/16962286/138767999-63b59c64-4bb7-4fd2-9d12-ecca37fdd862.png)
</details>