### PR TITLE
Chat Emotes

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,6 +7,9 @@ PODS:
     - Flutter
     - Libyuv (= 1703)
     - WebRTC-SDK (= 92.4515.07)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - Libyuv (1703)
   - package_info_plus (0.4.5):
     - Flutter
@@ -22,6 +25,9 @@ PODS:
     - Sentry (~> 7.3.0)
   - shared_preferences (0.0.1):
     - Flutter
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
   - uni_links (0.0.1):
     - Flutter
   - url_launcher (0.0.1):
@@ -36,11 +42,13 @@ DEPENDENCIES:
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 SPEC REPOS:
   trunk:
+    - FMDB
     - Libyuv
     - Reachability
     - Sentry
@@ -61,6 +69,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sentry_flutter/ios"
   shared_preferences:
     :path: ".symlinks/plugins/shared_preferences/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
   uni_links:
     :path: ".symlinks/plugins/uni_links/ios"
   url_launcher:
@@ -70,6 +80,7 @@ SPEC CHECKSUMS:
   connectivity_plus: 5f0eb61093bec56935f21a1699dd2758bc895587
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_webrtc: 6b71a1fc1d931a3dfe879e578ea10e2e6cd84f53
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   Libyuv: 5f79ced0ee66e60a612ca97de1e6ccacd187a437
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider: d1e9807085df1f9cc9318206cd649dc0b76be3de
@@ -77,6 +88,7 @@ SPEC CHECKSUMS:
   Sentry: 9a4e621430e2dae4477d791f2f7e905720b6efbf
   sentry_flutter: 08fadaed464f44e1233d3fbb0c72b10cebd79487
   shared_preferences: 5033afbb22d372e15aff8ff766df9021b845f273
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher: b6e016d912f04be9f5bf6e8e82dc599b7ba59649
   WebRTC-SDK: 540a44f2e30e89c75e331d5c4a372253ba668233

--- a/lib/blocs/repos/chat_messages_bloc.dart
+++ b/lib/blocs/repos/chat_messages_bloc.dart
@@ -102,7 +102,7 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
               .map((dynamic e) => ChatMessage(
                     username: e['node']['user']['username'] as String,
                     avatarUrl: e['node']['user']['avatarUrl'] as String,
-                    message: e['node']['message'] as String,
+                    tokens: _buildMessageTokensFromJson(e['node']['tokens']),
                   ))
               .toList();
 
@@ -120,7 +120,7 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
           ChatMessage chatMessage = ChatMessage(
             username: data['user']['username'] as String,
             avatarUrl: data['user']['avatarUrl'] as String,
-            message: data['message'] as String,
+            tokens: _buildMessageTokensFromJson(data['tokens']),
           );
 
           chatMessages.add(chatMessage);
@@ -139,6 +139,18 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
       print('$_ $stackTrace');
       yield state;
     }
+  }
+
+  List<MessageToken> _buildMessageTokensFromJson(List<dynamic> json) {
+    final List<MessageToken> tokens = json
+        .map((dynamic token) => MessageToken(
+              tokenType: token['type'] as String,
+              text: token['text'] as String,
+              src: token['src'] as String?,
+            ))
+        .toList();
+
+    return tokens;
   }
 
   Future<void> close() {

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:glimesh_app/blocs/repos/chat_messages_bloc.dart';
 import 'package:glimesh_app/models.dart';
 
@@ -133,13 +134,52 @@ class Chat extends StatelessWidget {
                 ),
               ),
               TextSpan(
-                text: message.username + ": " + message.message,
+                text: message.username + ": ",
                 style: TextStyle(fontSize: 16),
-              )
+              ),
+              ..._buildTokens(message.tokens)
             ]),
           ),
         ),
       ),
+    );
+  }
+
+  final double smallEmoteSize = 20;
+  final double bigEmoteSize = 64;
+
+  List<InlineSpan> _buildTokens(List<MessageToken> tokens) {
+    return tokens.map((token) {
+      if (token.tokenType == "emote" && token.src != null) {
+        // on the web, if an message is just an emote, we make it bigger, let's do that here too!
+        var emoteSize = tokens.length == 1 ? bigEmoteSize : smallEmoteSize;
+
+        return WidgetSpan(
+            child: Padding(
+                child: SizedBox(child: _drawEmote(token), width: emoteSize),
+                padding: EdgeInsets.symmetric(horizontal: 4)));
+      }
+
+      // we don't know the token type, or it's just text, just return the text for now.
+      return TextSpan(
+        text: token.text,
+        style: TextStyle(fontSize: 16),
+      );
+    }).toList();
+  }
+
+  // due to restrictions with flutter's selection of SVG libraries, we're having to use png
+  // emotes, which, given we never show them above text size 64, shouldn't *really* be an issue
+  Widget _drawEmote(MessageToken token) {
+    var url = token.src!;
+
+    if (token.src!.contains(".svg")) {
+      url = token.src!.replaceAll(".svg", ".png");
+    }
+
+    return Image(
+      image: CachedNetworkImageProvider(url),
+      filterQuality: FilterQuality.medium,
     );
   }
 }

--- a/lib/graphql/queries/chat.dart
+++ b/lib/graphql/queries/chat.dart
@@ -5,7 +5,13 @@ query GetSomeChatMessages($channelId: ID!) {
       edges {
         node {
           id
-          message
+          tokens {
+            type
+            ...on EmoteToken {
+              src
+            }
+            text
+          }
           user {
             username
             avatarUrl
@@ -20,7 +26,13 @@ query GetSomeChatMessages($channelId: ID!) {
 const String chatMessagesSubscription = r'''
 subscription ChatMessages($channelId: ID!) {
   chatMessage(channelId: $channelId) {
-    message
+    tokens {
+      type
+      ... on EmoteToken {
+        src
+      }
+      text
+    }
     user {
       username
       avatarUrl

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -40,16 +40,28 @@ class Social {
   final String username;
 }
 
+class MessageToken {
+  const MessageToken({
+    required this.tokenType,
+    required this.text,
+    this.src,
+  });
+
+  final String tokenType;
+  final String text;
+  final String? src;
+}
+
 class ChatMessage {
   const ChatMessage({
     required this.username,
-    required this.message,
     required this.avatarUrl,
+    required this.tokens,
   });
 
   final String username;
   final String avatarUrl;
-  final String message;
+  final List<MessageToken> tokens;
 }
 
 class Category {

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -41,10 +41,14 @@ class GlimeshRepository {
         document: parseString(channel_queries.queryHomepageChannels)));
   }
 
+  // fetchPolicy is set the noCache here due to issue #950 on graphql-flutter
+  // which seems to be causing issues with fragments?
+  // also, this fixes having old chat messages shown, which is nice
   Future<QueryResult> getSomeChatMessages(int channelId) {
     return client.query(QueryOptions(
       document: parseString(chat_queries.getSomeChatMessages),
       variables: <String, dynamic>{"channelId": channelId},
+      fetchPolicy: FetchPolicy.noCache,
     ));
   }
 
@@ -54,6 +58,7 @@ class GlimeshRepository {
         operationName: "ChatMessages",
         document: parseString(chat_queries.chatMessagesSubscription),
         variables: <String, dynamic>{"channelId": channelId},
+        fetchPolicy: FetchPolicy.noCache,
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,6 +36,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0+1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   characters:
     dependency: transitive
     description:
@@ -167,6 +188,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.3.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.3"
   flutter_markdown:
     dependency: "direct main"
     description:
@@ -359,6 +394,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0+1"
   package_info_plus:
     dependency: transitive
     description:
@@ -581,6 +623,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0+4"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -602,6 +658,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,13 +174,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.8"
-  flutter_svg:
-    dependency: "direct main"
-    description:
-      name: flutter_svg
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.23.0+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -415,20 +408,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  path_drawing:
-    dependency: transitive
-    description:
-      name: path_drawing
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.1+1"
-  path_parsing:
-    dependency: transitive
-    description:
-      name: path_parsing
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.1"
   path_provider:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.8"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.23.0+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -408,6 +415,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1+1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   path_provider:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   sentry_flutter: ^6.0.1
   font_awesome_flutter: ^9.1.0
   flutter_markdown: ^0.6.8
+  cached_network_image: ^3.1.0+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   sentry_flutter: ^6.0.1
   font_awesome_flutter: ^9.1.0
   flutter_markdown: ^0.6.8
+  flutter_svg: ^0.23.0+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,6 @@ dependencies:
   sentry_flutter: ^6.0.1
   font_awesome_flutter: ^9.1.0
   flutter_markdown: ^0.6.8
-  flutter_svg: ^0.23.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
(closes #4)

Adds emotes to chat (and makes it easier to display more things in chat as the chat system evolves) by reading message tokens instead of the plaintext the server sends.

Like the website, this PR changes the size of emotes depending on if a message is just a single emote. Animated emotes also work, and can change size too.

Due to issues with flutter's selection of SVG libraries (I haven't found any on the first few pages of search that support CSS <style> blocks), the code downloads PNG versions of SVG emotes.

All emotes get cached, to speed up future usages.

As usual, here's some screenshots:
(note that glimlol looks squished, I'm not fully sure why, the rest look fine?)
![IMG_0024](https://user-images.githubusercontent.com/16962286/142764032-ce2f9b52-adac-485c-8780-ffeeab453506.jpg)

![IMG_0025](https://user-images.githubusercontent.com/16962286/142764065-8d3e047f-ff5c-417d-b554-4592c9cfe680.jpg)

There's currently no UI in the app for sending emotes, but that's because there's nothing exposed over graphql yet for emotes.

Additionally, this PR disables result caching on getSomeChatMessages, partially because it was causing old messages to get shown and not new ones, and also because having it on breaks the fragment I needed to use to get the emote src.
