### PR TITLE
Keep the screen awake when a stream is being played

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -32,6 +32,8 @@ PODS:
     - Flutter
   - url_launcher (0.0.1):
     - Flutter
+  - wakelock (0.0.1):
+    - Flutter
   - WebRTC-SDK (92.4515.11)
 
 DEPENDENCIES:
@@ -45,6 +47,7 @@ DEPENDENCIES:
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
+  - wakelock (from `.symlinks/plugins/wakelock/ios`)
 
 SPEC REPOS:
   trunk:
@@ -75,6 +78,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/uni_links/ios"
   url_launcher:
     :path: ".symlinks/plugins/url_launcher/ios"
+  wakelock:
+    :path: ".symlinks/plugins/wakelock/ios"
 
 SPEC CHECKSUMS:
   connectivity_plus: 5f0eb61093bec56935f21a1699dd2758bc895587
@@ -91,6 +96,7 @@ SPEC CHECKSUMS:
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher: b6e016d912f04be9f5bf6e8e82dc599b7ba59649
+  wakelock: d0fc7c864128eac40eba1617cb5264d9c940b46f
   WebRTC-SDK: 21dbc6028a68f3a89718057a2caa970a4da8ebb7
 
 PODFILE CHECKSUM: 9388b2ab4c98804a24fefc585efd110a078cf07c

--- a/lib/components/FTLPlayer.dart
+++ b/lib/components/FTLPlayer.dart
@@ -7,6 +7,7 @@ import 'package:janus_streaming_client/JanusTransport.dart';
 import 'package:janus_streaming_client/shelf.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:glimesh_app/models.dart';
+import 'package:wakelock/wakelock.dart';
 
 class FTLPlayer extends StatefulWidget {
   final Channel channel;
@@ -74,10 +75,14 @@ class _FTLPlayerState extends State<FTLPlayer> {
   void initState() {
     super.initState();
     initJanusClient();
+
+    Wakelock.enable();
   }
 
   @override
   void dispose() {
+    Wakelock.disable();
+
     plugin!.send(data: {"request": "stop"});
 
     plugin!.dispose();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -692,7 +692,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -776,7 +776,42 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
+  wakelock:
+    dependency: "direct main"
+    description:
+      name: wakelock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1+1"
+  wakelock_macos:
+    dependency: transitive
+    description:
+      name: wakelock_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  wakelock_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  wakelock_web:
+    dependency: transitive
+    description:
+      name: wakelock_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  wakelock_windows:
+    dependency: transitive
+    description:
+      name: wakelock_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   font_awesome_flutter: ^9.1.0
   flutter_markdown: ^0.6.8
   cached_network_image: ^3.1.0+1
+  wakelock: ^0.6.1+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
(fixes #23)

This PR makes sure that the screen won't turn off when the user is watching a stream. I've used Wakelock instead of the flutter_incall library, as when I installed the latter, Flutter gave me deprecation warnings, and I couldn't find any forks that fixed it that were also pushed to pub.dev.

I haven't actually been able to replicate the issue when running with `flutter run`, which I think is because of how Flutter handles development, so I haven't been able to test, but I see no reason as to why it wouldn't work.

The lock is enabled when we init the Janus client, and disabled when the FTLPlayer component is destroyed.
It doesn't handle background playing or anything, just keeps the screen on, for now.
