### PR TITLE
Settings Screen (+a few other bits)

### DIFF
--- a/lib/blocs/repos/channel_list_bloc.dart
+++ b/lib/blocs/repos/channel_list_bloc.dart
@@ -4,7 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:glimesh_app/repository.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:glimesh_app/models.dart';
-import 'package:glimesh_app/lang_displaynames.dart';
+import 'package:glimesh_app/i18n.dart';
 
 @immutable
 abstract class ChannelListEvent extends Equatable {}

--- a/lib/blocs/repos/settings_bloc.dart
+++ b/lib/blocs/repos/settings_bloc.dart
@@ -1,0 +1,64 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:glimesh_app/repository.dart';
+
+@immutable
+abstract class SettingsEvent extends Equatable {}
+
+class InitSettingsData extends SettingsEvent {
+  InitSettingsData();
+  @override
+  List<Object> get props => [];
+}
+
+class ChangeTheme extends SettingsEvent {
+  final ThemeMode appTheme;
+
+  ChangeTheme({required this.appTheme});
+
+  @override
+  List<Object> get props => [this.appTheme];
+}
+
+@immutable
+abstract class SettingsState extends Equatable {}
+
+class InitialState extends SettingsState {
+  final ThemeMode theme;
+
+  InitialState({required this.theme});
+
+  @override
+  List<Object> get props => [theme];
+}
+
+class ThemeChanged extends SettingsState {
+  final ThemeMode newTheme;
+
+  ThemeChanged(this.newTheme);
+
+  @override
+  List<Object> get props => [newTheme];
+}
+
+class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
+  late SettingsRepository repo;
+
+  ThemeMode currentTheme = ThemeMode.system;
+
+  SettingsBloc() : super(InitialState(theme: ThemeMode.system)) {
+    on<InitSettingsData>((_, emit) async {
+      var prefs = await SharedPreferences.getInstance();
+      repo = SettingsRepository(prefs: prefs);
+      currentTheme = await repo.getTheme();
+      emit(InitialState(theme: currentTheme));
+    });
+    on<ChangeTheme>((event, emit) async {
+      currentTheme = event.appTheme;
+      await repo.setTheme(currentTheme);
+      emit(ThemeChanged(currentTheme));
+    });
+  }
+}

--- a/lib/components/ChannelCard.dart
+++ b/lib/components/ChannelCard.dart
@@ -32,7 +32,9 @@ class ChannelCard extends StatelessWidget {
           child: Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(20.0),
-              color: Colors.black54,
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? Colors.black54
+                  : Colors.white.withOpacity(0.85),
             ),
             padding: EdgeInsets.all(0),
             child: StreamTitle(channel: channel, allowMetadata: false),

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -98,7 +98,7 @@ class ChatMessages extends StatelessWidget {
             padding: EdgeInsets.only(top: 10, bottom: 10),
             physics: BouncingScrollPhysics(),
             itemBuilder: (context, index) {
-              return _buildChatMessage(state.messages[index]);
+              return _buildChatMessage(context, state.messages[index]);
             },
           );
         }
@@ -108,7 +108,7 @@ class ChatMessages extends StatelessWidget {
     );
   }
 
-  Widget _buildChatMessage(ChatMessage message) {
+  Widget _buildChatMessage(BuildContext context, ChatMessage message) {
     return Container(
       padding: EdgeInsets.all(3),
       child: Align(
@@ -116,7 +116,9 @@ class ChatMessages extends StatelessWidget {
         child: Container(
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(5),
-            color: Color(0xFF0E1826),
+            color: Theme.of(context).brightness == Brightness.dark
+                ? Color(0xFF0E1826)
+                : Colors.white70,
           ),
           padding: EdgeInsets.all(10),
           child: Text.rich(

--- a/lib/i18n.dart
+++ b/lib/i18n.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 // opted to do this instead of pulling in a whole dep to do this, esp. since we only
 // use a few langs and they're readily available on the main repo.
 const Map<String, String> languages = {
@@ -32,3 +34,32 @@ const Map<String, String> languages = {
   "sl": "slovenščina",
   "tr": "Türkçe",
 };
+
+const List<Locale> supportedLocales = [
+  Locale('en'),
+  Locale('cs'),
+  Locale('da'),
+  Locale('de'),
+  Locale('es'),
+  Locale('es', 'AR'),
+  Locale('es', 'MX'),
+  Locale('fr'),
+  Locale('hu'),
+  Locale('it'),
+  Locale('ja'),
+  Locale('ko'),
+  Locale('nb'),
+  Locale('nl'),
+  Locale('no'),
+  Locale('pl'),
+  Locale('pt'),
+  Locale('pt', 'BR'),
+  Locale('ru'),
+  Locale('sv'),
+  Locale('tr'),
+  Locale('vi'),
+  // the two below are broken for some reason, getttext can see them, and the Material
+  // translations work, but trying to use them results in English text
+  /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), */
+  /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), */
+];

--- a/lib/i18n.dart
+++ b/lib/i18n.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 
 // opted to do this instead of pulling in a whole dep to do this, esp. since we only
 // use a few langs and they're readily available on the main repo.
+// Português Brasileiro is defined twice as pt_BR is the "correct" version, but for
+// some reason, when we ask for a stream language pt_br is returned - this should
+// probably be fixed in GlimeshWeb
 const Map<String, String> languages = {
   "en": "English",
   "es": "Español",
@@ -23,6 +26,7 @@ const Map<String, String> languages = {
   "pl": "Polski",
   "ro": "Limba Română",
   "pt_br": "Português Brasileiro",
+  "pt_BR": "Português Brasileiro",
   "pt": "Português",
   "zh_Hans": "中文 (简体)",
   "zh_Hant": "中文 (繁体)",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:glimesh_app/screens/SettingsScreen.dart';
 import 'package:glimesh_app/models.dart';
 import 'package:glimesh_app/repository.dart';
 import 'package:glimesh_app/glimesh.dart';
+import 'package:glimesh_app/i18n.dart';
 
 class MyHttpOverrides extends HttpOverrides {
   @override
@@ -224,34 +225,7 @@ class GlimeshApp extends StatelessWidget {
                     GlobalMaterialLocalizations.delegate,
                     GlobalWidgetsLocalizations.delegate
                   ],
-                  supportedLocales: [
-                    Locale('en'),
-                    Locale('cs'),
-                    Locale('da'),
-                    Locale('de'),
-                    Locale('es'),
-                    Locale('es', 'AR'),
-                    Locale('es', 'MX'),
-                    Locale('fr'),
-                    Locale('hu'),
-                    Locale('it'),
-                    Locale('ja'),
-                    Locale('ko'),
-                    Locale('nb'),
-                    Locale('nl'),
-                    Locale('no'),
-                    Locale('pl'),
-                    Locale('pt'),
-                    Locale('pt', 'BR'),
-                    Locale('ru'),
-                    Locale('sv'),
-                    Locale('tr'),
-                    Locale('vi'),
-                    // the two below are broken for some reason, getttext can see them, and the Material
-                    // translations work, but trying to use them results in English text
-                    /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), */
-                    /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), */
-                  ],
+                  supportedLocales: supportedLocales,
                   darkTheme: ThemeData(
                     brightness: Brightness.dark,
                     primaryColor: Color(0xff060818),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -228,12 +228,19 @@ class GlimeshApp extends StatelessWidget {
                   locale:
                       context.select((SettingsBloc bloc) => bloc.currentLocale),
                   supportedLocales: supportedLocales,
+                  theme: ThemeData(
+                      brightness: Brightness.light,
+                      appBarTheme: AppBarTheme(
+                          color: Colors.white, foregroundColor: Colors.black),
+                      textTheme:
+                          TextTheme(headline4: TextStyle(color: Colors.black))),
                   darkTheme: ThemeData(
-                    brightness: Brightness.dark,
-                    primaryColor: Color(0xff060818),
-                    canvasColor: Color(0xff060818),
-                    bottomAppBarColor: Color(0xff0e1726),
-                  ),
+                      brightness: Brightness.dark,
+                      canvasColor: Color(0xff060818),
+                      bottomAppBarColor: Color(0xff0e1726),
+                      appBarTheme: AppBarTheme(color: Colors.black),
+                      textTheme:
+                          TextTheme(headline4: TextStyle(color: Colors.white))),
                   themeMode:
                       context.select((SettingsBloc bloc) => bloc.currentTheme),
                   home: authState!.client != null

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -225,6 +225,8 @@ class GlimeshApp extends StatelessWidget {
                     GlobalMaterialLocalizations.delegate,
                     GlobalWidgetsLocalizations.delegate
                   ],
+                  locale:
+                      context.select((SettingsBloc bloc) => bloc.currentLocale),
                   supportedLocales: supportedLocales,
                   darkTheme: ThemeData(
                     brightness: Brightness.dark,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,71 +203,7 @@ class GlimeshApp extends StatelessWidget {
       '/settings': (context) => SettingsScreen()
     };
 
-    final generateRoutes = (settings) {
-      if (settings.name == '/channel') {
-        final Channel channel = settings.arguments as Channel;
-        final GlimeshRepository repo =
-            GlimeshRepository(client: authState!.client!);
-        final ChannelBloc bloc = ChannelBloc(
-          glimeshRepository: repo,
-        );
-
-        return MaterialPageRoute(
-          builder: (context) {
-            print("MaterialPageRoute build");
-            return MultiBlocProvider(
-              providers: [
-                // Channel Bloc
-                BlocProvider<ChannelBloc>(
-                  create: (context) =>
-                      bloc..add(WatchChannel(channelId: channel.id)),
-                ),
-                // ChatMessagesBloc
-                BlocProvider<ChatMessagesBloc>(
-                  create: (context) => ChatMessagesBloc(glimeshRepository: repo)
-                    ..add(LoadChatMessages(channelId: channel.id)),
-                ),
-                // Follow Bloc
-                BlocProvider<FollowBloc>(
-                  create: (context) {
-                    FollowBloc bloc = FollowBloc(glimeshRepository: repo);
-                    // If we're authenticated, show the initial bloc status
-                    if (authState.authenticated) {
-                      bloc.add(LoadFollowStatus(
-                        streamerId: channel.user_id,
-                        userId: authState.user!.id,
-                      ));
-                    }
-                    return bloc;
-                  },
-                ),
-              ],
-              child: ChannelScreen(channel: channel),
-            );
-          },
-        );
-      }
-
-      if (settings.name == '/profile') {
-        final String username = settings.arguments as String;
-
-        return MaterialPageRoute(
-          builder: (context) {
-            return BlocProvider(
-              create: (context) => UserBloc(
-                glimeshRepository:
-                    GlimeshRepository(client: authState!.client!),
-              ),
-              child: UserProfileScreen(username: username),
-            );
-          },
-        );
-      }
-
-      // Fail if we're missing any routes.
-      assert(false, 'Need to implement ${settings.name}');
-      return null;
-    };
+    final generateRoutes = (settings) => _generateRoutes(settings, authState);
 
     print("New State for MaterialApp");
 
@@ -323,5 +259,70 @@ class GlimeshApp extends StatelessWidget {
           ? AppScreen(title: "Glimesh")
           : Padding(padding: EdgeInsets.zero),
     );
+  }
+
+  MaterialPageRoute? _generateRoutes(settings, authState) {
+    if (settings.name == '/channel') {
+      final Channel channel = settings.arguments as Channel;
+      final GlimeshRepository repo =
+          GlimeshRepository(client: authState!.client!);
+      final ChannelBloc bloc = ChannelBloc(
+        glimeshRepository: repo,
+      );
+
+      return MaterialPageRoute(
+        builder: (context) {
+          print("MaterialPageRoute build");
+          return MultiBlocProvider(
+            providers: [
+              // Channel Bloc
+              BlocProvider<ChannelBloc>(
+                create: (context) =>
+                    bloc..add(WatchChannel(channelId: channel.id)),
+              ),
+              // ChatMessagesBloc
+              BlocProvider<ChatMessagesBloc>(
+                create: (context) => ChatMessagesBloc(glimeshRepository: repo)
+                  ..add(LoadChatMessages(channelId: channel.id)),
+              ),
+              // Follow Bloc
+              BlocProvider<FollowBloc>(
+                create: (context) {
+                  FollowBloc bloc = FollowBloc(glimeshRepository: repo);
+                  // If we're authenticated, show the initial bloc status
+                  if (authState.authenticated) {
+                    bloc.add(LoadFollowStatus(
+                      streamerId: channel.user_id,
+                      userId: authState.user!.id,
+                    ));
+                  }
+                  return bloc;
+                },
+              ),
+            ],
+            child: ChannelScreen(channel: channel),
+          );
+        },
+      );
+    }
+
+    if (settings.name == '/profile') {
+      final String username = settings.arguments as String;
+
+      return MaterialPageRoute(
+        builder: (context) {
+          return BlocProvider(
+            create: (context) => UserBloc(
+              glimeshRepository: GlimeshRepository(client: authState!.client!),
+            ),
+            child: UserProfileScreen(username: username),
+          );
+        },
+      );
+    }
+
+    // Fail if we're missing any routes.
+    assert(false, 'Need to implement ${settings.name}');
+    return null;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:glimesh_app/blocs/repos/channel_bloc.dart';
 import 'package:glimesh_app/blocs/repos/chat_messages_bloc.dart';
 import 'package:glimesh_app/blocs/repos/follow_bloc.dart';
+import 'package:glimesh_app/blocs/repos/settings_bloc.dart';
 import 'package:glimesh_app/screens/AppScreen.dart';
 import 'package:gql_phoenix_link/gql_phoenix_link.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
@@ -192,10 +193,10 @@ class GlimeshApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final authState = AuthState.of(context);
 
-    final whiteTextTheme = Theme.of(context).textTheme.apply(
-          bodyColor: Colors.white,
-          displayColor: Colors.white,
-        );
+    /* final whiteTextTheme = Theme.of(context).textTheme.apply( */
+    /*       bodyColor: Colors.white, */
+    /*       displayColor: Colors.white, */
+    /*     ); */
 
     final routes = <String, WidgetBuilder>{
       '/channels': (context) => ChannelListScreen(),
@@ -207,58 +208,62 @@ class GlimeshApp extends StatelessWidget {
 
     print("New State for MaterialApp");
 
-    return MaterialApp(
-      title: 'Glimesh Alpha',
-      routes: routes,
-      onGenerateRoute: generateRoutes,
-      localizationsDelegates: [
-        GettextLocalizationsDelegate(defaultLanguage: 'en'),
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate
-      ],
-      supportedLocales: [
-        Locale('en'),
-        Locale('cs'),
-        Locale('da'),
-        Locale('de'),
-        Locale('es'),
-        Locale('es', 'AR'),
-        Locale('es', 'MX'),
-        Locale('fr'),
-        Locale('hu'),
-        Locale('it'),
-        Locale('ja'),
-        Locale('ko'),
-        Locale('nb'),
-        Locale('nl'),
-        Locale('no'),
-        Locale('pl'),
-        Locale('pt'),
-        Locale('pt', 'BR'),
-        Locale('ru'),
-        Locale('sv'),
-        Locale('tr'),
-        Locale('vi'),
-        // the two below are broken for some reason, getttext can see them, and the Material
-        // translations work, but trying to use them results in English text
-        /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), */
-        /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), */
-      ],
-      theme: ThemeData(
-        brightness: Brightness.dark,
-      ),
-      darkTheme: ThemeData(
-        brightness: Brightness.dark,
-        primaryColor: Color(0xff060818),
-        canvasColor: Color(0xff060818),
-        bottomAppBarColor: Color(0xff0e1726),
-        textTheme: whiteTextTheme,
-      ),
-      themeMode: ThemeMode.dark,
-      home: authState!.client != null
-          ? AppScreen(title: "Glimesh")
-          : Padding(padding: EdgeInsets.zero),
-    );
+    return BlocProvider(
+        create: (_) {
+          var bloc = SettingsBloc();
+          bloc..add(InitSettingsData());
+          return bloc;
+        },
+        child: BlocBuilder<SettingsBloc, SettingsState>(
+            builder: (context, _) => MaterialApp(
+                  title: 'Glimesh Alpha',
+                  routes: routes,
+                  onGenerateRoute: generateRoutes,
+                  localizationsDelegates: [
+                    GettextLocalizationsDelegate(defaultLanguage: 'en'),
+                    GlobalMaterialLocalizations.delegate,
+                    GlobalWidgetsLocalizations.delegate
+                  ],
+                  supportedLocales: [
+                    Locale('en'),
+                    Locale('cs'),
+                    Locale('da'),
+                    Locale('de'),
+                    Locale('es'),
+                    Locale('es', 'AR'),
+                    Locale('es', 'MX'),
+                    Locale('fr'),
+                    Locale('hu'),
+                    Locale('it'),
+                    Locale('ja'),
+                    Locale('ko'),
+                    Locale('nb'),
+                    Locale('nl'),
+                    Locale('no'),
+                    Locale('pl'),
+                    Locale('pt'),
+                    Locale('pt', 'BR'),
+                    Locale('ru'),
+                    Locale('sv'),
+                    Locale('tr'),
+                    Locale('vi'),
+                    // the two below are broken for some reason, getttext can see them, and the Material
+                    // translations work, but trying to use them results in English text
+                    /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans'), */
+                    /* Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'), */
+                  ],
+                  darkTheme: ThemeData(
+                    brightness: Brightness.dark,
+                    primaryColor: Color(0xff060818),
+                    canvasColor: Color(0xff060818),
+                    bottomAppBarColor: Color(0xff0e1726),
+                  ),
+                  themeMode:
+                      context.select((SettingsBloc bloc) => bloc.currentTheme),
+                  home: authState!.client != null
+                      ? AppScreen(title: "Glimesh")
+                      : Padding(padding: EdgeInsets.zero),
+                )));
   }
 
   MaterialPageRoute? _generateRoutes(settings, authState) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -194,11 +194,6 @@ class GlimeshApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final authState = AuthState.of(context);
 
-    /* final whiteTextTheme = Theme.of(context).textTheme.apply( */
-    /*       bodyColor: Colors.white, */
-    /*       displayColor: Colors.white, */
-    /*     ); */
-
     final routes = <String, WidgetBuilder>{
       '/channels': (context) => ChannelListScreen(),
       '/login': (context) => LoginScreen(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:glimesh_app/screens/ProfileScreen.dart';
 import 'package:glimesh_app/auth.dart';
 import 'package:glimesh_app/blocs/repos/user_bloc.dart';
 import 'package:glimesh_app/screens/ChannelScreen.dart';
+import 'package:glimesh_app/screens/SettingsScreen.dart';
 import 'package:glimesh_app/models.dart';
 import 'package:glimesh_app/repository.dart';
 import 'package:glimesh_app/glimesh.dart';
@@ -198,7 +199,8 @@ class GlimeshApp extends StatelessWidget {
 
     final routes = <String, WidgetBuilder>{
       '/channels': (context) => ChannelListScreen(),
-      '/login': (context) => LoginScreen()
+      '/login': (context) => LoginScreen(),
+      '/settings': (context) => SettingsScreen()
     };
 
     final generateRoutes = (settings) {

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -107,17 +107,17 @@ class GlimeshRepository {
 }
 
 class SettingsRepository {
-	final SharedPreferences prefs;
-	SettingsRepository({required this.prefs});
+  final SharedPreferences prefs;
+  SettingsRepository({required this.prefs});
 
-	Future<ThemeMode> getTheme() async {
-		// get the theme, or default to the system theme
-		var theme_idx = prefs.getInt("settings.theme") ?? 0;
+  Future<ThemeMode> getTheme() async {
+    // get the theme, or default to the system theme
+    var theme_idx = prefs.getInt("settings.theme") ?? 0;
 
-		return ThemeMode.values[theme_idx];
-	}
+    return ThemeMode.values[theme_idx];
+  }
 
-	setTheme(ThemeMode theme) async {
-		await prefs.setInt("settings.theme", theme.index);
-	}
+  setTheme(ThemeMode theme) async {
+    await prefs.setInt("settings.theme", theme.index);
+  }
 }

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -120,4 +120,31 @@ class SettingsRepository {
   setTheme(ThemeMode theme) async {
     await prefs.setInt("settings.theme", theme.index);
   }
+
+  Future<Locale?> getLocale() async {
+    var locale_lang = prefs.getString("settings.locale.lang");
+    var locale_script = prefs.getString("settings.locale.script");
+    var locale_country = prefs.getString("settings.locale.country");
+
+    if (locale_lang == null) return null;
+
+    return Locale.fromSubtags(
+        languageCode: locale_lang,
+        scriptCode: locale_script,
+        countryCode: locale_country);
+  }
+
+  setLocale(Locale locale) async {
+    prefs.setString("settings.locale.lang", locale.languageCode);
+
+    var locale_script = locale.scriptCode;
+    var locale_country = locale.countryCode;
+
+    locale_script == null
+        ? prefs.remove("settings.locale.script")
+        : prefs.setString("settings.locale.script", locale_script);
+    locale_country == null
+        ? prefs.remove("settings.locale.country")
+        : prefs.setString("settings.locale.country", locale_country);
+  }
 }

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'package:flutter/material.dart';
 
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:gql/language.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:glimesh_app/graphql/queries/channels.dart' as channel_queries;
 import 'package:glimesh_app/graphql/queries/chat.dart' as chat_queries;
 import 'package:glimesh_app/graphql/queries/user.dart' as user_queries;
@@ -102,4 +104,20 @@ class GlimeshRepository {
       variables: <String, dynamic>{"streamerId": streamerId},
     ));
   }
+}
+
+class SettingsRepository {
+	final SharedPreferences prefs;
+	SettingsRepository({required this.prefs});
+
+	Future<ThemeMode> getTheme() async {
+		// get the theme, or default to the system theme
+		var theme_idx = prefs.getInt("settings.theme") ?? 0;
+
+		return ThemeMode.values[theme_idx];
+	}
+
+	setTheme(ThemeMode theme) async {
+		await prefs.setInt("settings.theme", theme.index);
+	}
 }

--- a/lib/screens/AppScreen.dart
+++ b/lib/screens/AppScreen.dart
@@ -94,6 +94,10 @@ class _AppScreenState extends State<AppScreen> {
                   Navigator.pushNamed(context, '/login');
                 },
               ),
+            ListTile(
+                leading: Icon(Icons.settings),
+                title: Text(context.t("Settings")),
+                onTap: () => Navigator.pushNamed(context, '/settings')),
             if (authState.authenticated == true)
               ListTile(
                 leading: Icon(Icons.logout),

--- a/lib/screens/AppScreen.dart
+++ b/lib/screens/AppScreen.dart
@@ -51,7 +51,6 @@ class _AppScreenState extends State<AppScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
-        backgroundColor: Colors.black.withOpacity(0.7),
         // leading: IconButton(icon: const Icon(Icons.menu), onPressed: () => {}),
         actions: [
           // IconButton(

--- a/lib/screens/CategoryListScreen.dart
+++ b/lib/screens/CategoryListScreen.dart
@@ -154,7 +154,7 @@ class CategoryListWidget extends StatelessWidget {
     return Expanded(
       child: Container(
         padding: EdgeInsets.all(10),
-        child: ElevatedButton(
+        child: OutlinedButton(
           onPressed: () => Navigator.pushNamed(
             context,
             '/channels',
@@ -170,10 +170,12 @@ class CategoryListWidget extends StatelessWidget {
               Text(context.t(category.name))
             ],
           ),
-          style: ElevatedButton.styleFrom(
+          style: OutlinedButton.styleFrom(
             side: BorderSide(width: 1, color: Colors.grey),
             textStyle: Theme.of(context).textTheme.headline6,
-            primary: Colors.transparent,
+            primary: Theme.of(context).brightness == Brightness.dark
+                ? Colors.white
+                : Colors.black,
             padding: EdgeInsets.all(20),
           ),
         ),

--- a/lib/screens/ChannelListScreen.dart
+++ b/lib/screens/ChannelListScreen.dart
@@ -19,7 +19,6 @@ class ChannelListScreen extends StatelessWidget {
             .t("%{category} Streams")
             .toString()
             .replaceAll("%{category}", context.t(category.name))),
-        backgroundColor: Colors.black.withOpacity(0.7),
       ),
       body: BlocProvider(
         create: (context) => ChannelListBloc(

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -64,6 +64,8 @@ class ChannelScreen extends StatelessWidget {
         );
 
         return Scaffold(
+          // appBar here with 0 height just to make the background of the status bar black
+          appBar: AppBar(toolbarHeight: 0.0),
           body: SafeArea(
             child: LayoutBuilder(
               builder: (BuildContext context, BoxConstraints constraints) {

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -64,8 +64,6 @@ class _SettingsWidgetState extends State<SettingsWidget> {
             child: Text(languages[locale.toString()] ?? locale.toString())))
         .toList();
 
-    localeList.forEach((locale) => print(locale.value));
-
     return Row(
       children: [
         Text(context.t("Language")),

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:gettext_i18n/gettext_i18n.dart';
+
+class SettingsScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SettingsWidget();
+  }
+}
+
+class SettingsWidget extends StatefulWidget {
+  @override
+  State<SettingsWidget> createState() => _SettingsWidgetState();
+}
+
+class _SettingsWidgetState extends State<SettingsWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(context.t('Settings'))),
+      body: Container(
+        child: Text("Settings page"),
+        margin: EdgeInsets.all(4),
+      ),
+    );
+  }
+}

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -22,7 +22,10 @@ class _SettingsWidgetState extends State<SettingsWidget> {
     return Scaffold(
       appBar: AppBar(title: Text(context.t('Settings'))),
       body: Container(
-        child: _buildThemeSelector(context),
+        child: Column(children: [
+          _buildThemeSelector(context),
+          _buildLocaleSelector(context)
+        ]),
         margin: EdgeInsets.all(4),
       ),
     );
@@ -51,6 +54,31 @@ class _SettingsWidgetState extends State<SettingsWidget> {
             });
           },
         )
+      ],
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    );
+  }
+
+  Widget _buildLocaleSelector(BuildContext context) {
+    final localeList = supportedLocales
+        .map((locale) => DropdownMenuItem(
+            value: locale,
+            child: Text(languages[locale.toString()] ?? locale.toString())))
+        .toList();
+
+    localeList.forEach((locale) => print(locale.value));
+
+    return Row(
+      children: [
+        Text(context.t("Language")),
+        DropdownButton<Locale>(
+            items: localeList,
+            value: context.select((SettingsBloc bloc) => bloc.currentLocale),
+            onChanged: (Locale? newLocale) {
+              context
+                  .read<SettingsBloc>()
+                  .add(ChangeLocale(locale: newLocale ?? Locale('en')));
+            }),
       ],
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
     );

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gettext_i18n/gettext_i18n.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:glimesh_app/blocs/repos/settings_bloc.dart';
 
 class SettingsScreen extends StatelessWidget {
   @override
@@ -19,9 +21,37 @@ class _SettingsWidgetState extends State<SettingsWidget> {
     return Scaffold(
       appBar: AppBar(title: Text(context.t('Settings'))),
       body: Container(
-        child: Text("Settings page"),
+        child: _buildThemeSelector(context),
         margin: EdgeInsets.all(4),
       ),
+    );
+  }
+
+  Widget _buildThemeSelector(BuildContext context) {
+    return Row(
+      children: [
+        Text(context.t("Theme")),
+        DropdownButton<ThemeMode>(
+          value: context.select((SettingsBloc bloc) => bloc.currentTheme),
+          items: <DropdownMenuItem<ThemeMode>>[
+            DropdownMenuItem(
+                value: ThemeMode.system,
+                child: Text(context.t("System Theme"))),
+            DropdownMenuItem(
+                value: ThemeMode.light, child: Text(context.t("Light"))),
+            DropdownMenuItem(
+                value: ThemeMode.dark, child: Text(context.t("Dark"))),
+          ],
+          onChanged: (ThemeMode? newValue) {
+            setState(() {
+              context
+                  .read<SettingsBloc>()
+                  .add(ChangeTheme(appTheme: newValue ?? ThemeMode.system));
+            });
+          },
+        )
+      ],
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
     );
   }
 }

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:gettext_i18n/gettext_i18n.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:glimesh_app/blocs/repos/settings_bloc.dart';
+import 'package:glimesh_app/i18n.dart';
 
 class SettingsScreen extends StatelessWidget {
   @override

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -47,11 +47,9 @@ class _SettingsWidgetState extends State<SettingsWidget> {
                 value: ThemeMode.dark, child: Text(context.t("Dark"))),
           ],
           onChanged: (ThemeMode? newValue) {
-            setState(() {
-              context
-                  .read<SettingsBloc>()
-                  .add(ChangeTheme(appTheme: newValue ?? ThemeMode.system));
-            });
+            context
+                .read<SettingsBloc>()
+                .add(ChangeTheme(appTheme: newValue ?? ThemeMode.system));
           },
         )
       ],


### PR DESCRIPTION
This PR closes #12 by adding a settings screen, the option appears in the drawer alongside login/logout.

Currently in the settings screen, we have the locale selector, as mentioned in #42. However, due to the way the screen is built, the language is by default now English and will not be automatically detected based on the user's device settings, they will need to set it manually in our Settings (just like on the website)

There's also a dark mode / light mode / system theme dropdown, which defaults to the system theme. A few changes have been made across the app to improve the light mode experience, including adding a zero height AppBar to the ChannelScreen, which gives us a black status bar (on iOS) instead of having white status bar text on a white background.
When the dropdown is set to system theme, Flutter will automatically switch between dark mode and light mode based on the user's device preferences, including if the user changes their system theme while the app is running!

Of course both of these settings persist over restarts, thanks to a complete and utter mess of repo and bloc code.

Once this is merged, I'll probably work on the Mature Content popup, which I'll split into a separate issue from #12.