### PR TITLE
Add the Mature Content Warning

### DIFF
--- a/lib/blocs/repos/channel_bloc.dart
+++ b/lib/blocs/repos/channel_bloc.dart
@@ -7,6 +7,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:glimesh_app/repository.dart';
 import 'package:glimesh_app/models.dart';
+import 'package:glimesh_app/blocs/repos/settings_bloc.dart';
 
 /* Events */
 @immutable
@@ -30,9 +31,24 @@ class WatchChannel extends ChannelEvent {
   List<Object> get props => [this.channelId];
 }
 
+class ShowMatureWarning extends ChannelEvent {
+  final Channel channel;
+  final SettingsBloc settingsBloc;
+
+  ShowMatureWarning({required this.channel, required this.settingsBloc});
+
+  @override
+  List<Object?> get props => [this.channel, this.settingsBloc];
+}
+
 /* State */
 @immutable
 abstract class ChannelState extends Equatable {}
+
+class ChannelShowMatureWarning extends ChannelState {
+  @override
+  List<Object?> get props => [];
+}
 
 class ChannelLoading extends ChannelState {
   @override
@@ -78,6 +94,15 @@ class ChannelBloc extends Bloc<ChannelEvent, ChannelState> {
       emit(ChannelReady(
         edgeRoute: edgeRoute,
       ));
+    });
+
+    on<ShowMatureWarning>((event, emit) async {
+      if (event.settingsBloc.bypassMatureWarning ||
+          !event.channel.matureContent) {
+        this.add(WatchChannel(channelId: event.channel.id));
+      } else {
+        emit(ChannelShowMatureWarning());
+      }
     });
   }
 

--- a/lib/blocs/repos/settings_bloc.dart
+++ b/lib/blocs/repos/settings_bloc.dart
@@ -31,14 +31,27 @@ class ChangeLocale extends SettingsEvent {
   List<Object> get props => [this.locale];
 }
 
+class ChangeBypassMatureWarning extends SettingsEvent {
+  final bool shouldBypass;
+
+  ChangeBypassMatureWarning({required this.shouldBypass});
+
+  @override
+  List<Object> get props => [this.shouldBypass];
+}
+
 @immutable
 abstract class SettingsState extends Equatable {}
 
 class InitialState extends SettingsState {
   final ThemeMode theme;
   final Locale locale;
+  final bool bypassMatureWarning;
 
-  InitialState({required this.theme, required this.locale});
+  InitialState(
+      {required this.theme,
+      required this.locale,
+      required this.bypassMatureWarning});
 
   @override
   List<Object> get props => [theme, locale];
@@ -62,30 +75,58 @@ class LocaleChanged extends SettingsState {
   List<Object> get props => [newLocale];
 }
 
+class BypassMatureWarningChanged extends SettingsState {
+  final bool shouldBypass;
+
+  BypassMatureWarningChanged(this.shouldBypass);
+
+  @override
+  List<Object> get props => [this.shouldBypass];
+}
+
 class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   late SettingsRepository repo;
 
   ThemeMode currentTheme = ThemeMode.system;
   Locale currentLocale = Locale("en");
+  bool bypassMatureWarning = false;
 
   SettingsBloc()
-      : super(InitialState(theme: ThemeMode.system, locale: Locale('en'))) {
+      : super(InitialState(
+            theme: ThemeMode.system,
+            locale: Locale('en'),
+            bypassMatureWarning: false)) {
     on<InitSettingsData>((_, emit) async {
       var prefs = await SharedPreferences.getInstance();
+
       repo = SettingsRepository(prefs: prefs);
+
       currentTheme = await repo.getTheme();
       currentLocale = await repo.getLocale() ?? Locale('en');
-      emit(InitialState(theme: currentTheme, locale: currentLocale));
+      bypassMatureWarning = await repo.getShouldBypassMatureWarning();
+
+      emit(InitialState(
+          theme: currentTheme,
+          locale: currentLocale,
+          bypassMatureWarning: bypassMatureWarning));
     });
+
     on<ChangeTheme>((event, emit) async {
       currentTheme = event.appTheme;
       await repo.setTheme(currentTheme);
       emit(ThemeChanged(currentTheme));
     });
+
     on<ChangeLocale>((event, emit) async {
       currentLocale = event.locale;
       await repo.setLocale(currentLocale);
       emit(LocaleChanged(currentLocale));
+    });
+
+    on<ChangeBypassMatureWarning>((event, emit) async {
+      bypassMatureWarning = event.shouldBypass;
+      await repo.setShouldBypassMatureWarning(bypassMatureWarning);
+      emit(BypassMatureWarningChanged(bypassMatureWarning));
     });
   }
 }

--- a/lib/components/MatureWarning.dart
+++ b/lib/components/MatureWarning.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:gettext_i18n/gettext_i18n.dart';
+
+class MatureWarning extends StatelessWidget {
+  final void Function() onAccept;
+
+  MatureWarning({required this.onAccept});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+        child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          context.t("Mature Content Warning"),
+          style: Theme.of(context).textTheme.headline4,
+        ),
+        Text(
+          context.t(
+              "The streamer has flagged this channel as only appropriate for Mature Audiences."),
+          style: Theme.of(context).textTheme.subtitle1,
+        ),
+        Text(
+          context.t("Do you wish to continue?"),
+          style: Theme.of(context).textTheme.subtitle1,
+        ),
+        Padding(
+          child: OutlinedButton(
+            child: Text(context.t("Agree & View Channel")),
+            onPressed: onAccept,
+          ),
+          padding: EdgeInsets.symmetric(vertical: 8),
+        ),
+        ElevatedButton(
+          child: Text(context.t("Go Back")),
+          onPressed: () => Navigator.pop(context),
+        )
+      ],
+    ));
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -263,8 +263,10 @@ class GlimeshApp extends StatelessWidget {
             providers: [
               // Channel Bloc
               BlocProvider<ChannelBloc>(
-                create: (context) =>
-                    bloc..add(WatchChannel(channelId: channel.id)),
+                create: (context) => bloc
+                  ..add(ShowMatureWarning(
+                      channel: channel,
+                      settingsBloc: context.read<SettingsBloc>())),
               ),
               // ChatMessagesBloc
               BlocProvider<ChatMessagesBloc>(

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -147,4 +147,12 @@ class SettingsRepository {
         ? prefs.remove("settings.locale.country")
         : prefs.setString("settings.locale.country", locale_country);
   }
+
+  Future<bool> getShouldBypassMatureWarning() async {
+    return prefs.getBool("settings.bypassMatureWarning") ?? false;
+  }
+
+  setShouldBypassMatureWarning(bool value) async {
+    prefs.setBool("settings.bypassMatureWarning", value);
+  }
 }

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -5,6 +5,7 @@ import 'package:glimesh_app/components/Chat.dart';
 import 'package:glimesh_app/components/FTLPlayer.dart';
 import 'package:glimesh_app/components/StreamTitle.dart';
 import 'package:glimesh_app/components/Loading.dart';
+import 'package:glimesh_app/components/MatureWarning.dart';
 import 'package:glimesh_app/models.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:gettext_i18n/gettext_i18n.dart';
@@ -23,6 +24,18 @@ class ChannelScreen extends StatelessWidget {
         return Scaffold(
           body: SafeArea(
             child: _backButtonContainer(context, Loading(context.t("Loading Stream"))),
+          ),
+        );
+      }
+
+      if (state is ChannelShowMatureWarning) {
+        return Scaffold(
+          body: SafeArea(
+            child: MatureWarning(onAccept: () {
+              context
+                  .read<ChannelBloc>()
+                  .add(WatchChannel(channelId: channel.id));
+            }),
           ),
         );
       }

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -24,7 +24,8 @@ class _SettingsWidgetState extends State<SettingsWidget> {
       body: Container(
         child: Column(children: [
           _buildThemeSelector(context),
-          _buildLocaleSelector(context)
+          _buildLocaleSelector(context),
+          _buildMatureWarningToggle(context),
         ]),
         margin: EdgeInsets.all(4),
       ),
@@ -78,5 +79,19 @@ class _SettingsWidgetState extends State<SettingsWidget> {
       ],
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
     );
+  }
+
+  Widget _buildMatureWarningToggle(BuildContext context) {
+    return Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+      Text(context.t("Bypass Mature Content Warning")),
+      Switch(
+        value: context.select((SettingsBloc bloc) => bloc.bypassMatureWarning),
+        onChanged: (newVal) {
+          context
+              .read<SettingsBloc>()
+              .add(ChangeBypassMatureWarning(shouldBypass: newVal));
+        },
+      ),
+    ]);
   }
 }


### PR DESCRIPTION
A smaller PR for a change (although some more bloc-dances take place), I've added the Mature Content Warning, which will appear before a mature stream.

I've done this by hijacking ChannelBloc, so that instead of going straight to WatchStream, if the stream is mature and bypass is false, we show the warning, which can either pop back to the previous page if the user denies, or will continue with WatchStream if the user agrees.

Customary screenshot:
![IMG_2D6CAF51006E-1](https://user-images.githubusercontent.com/16962286/158018002-e02c64ee-dfff-46f2-8cb1-e80be3022f68.jpeg)

Also, if the user wishes, just like the Website, they have the option to go in to the app settings and disable the warning if they so desire.