### PR TITLE
Attempt fixing Flutter 2.10 builds

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,6 +408,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -582,7 +589,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   plausible_analytics:
     dependency: "direct main"
     description:
@@ -748,7 +755,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
At some point between flutter 2.5 and 2.10, io.platform.packageRoot was deprecated and removed, which causes build errors on up-to-date flutter versions. This PR upgrades the platform package, which should fix this.