### PR TITLE
Chat Only Mode

### DIFF
--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -22,6 +22,7 @@ class ChannelScreen extends StatefulWidget {
 class _ChannelScreenState extends State<ChannelScreen> {
   final Channel channel;
   bool isChatOnlyMode = false;
+  bool showControls = true;
 
   _ChannelScreenState({required this.channel}) : super();
 
@@ -148,6 +149,27 @@ class _ChannelScreenState extends State<ChannelScreen> {
         )
       ],
     );
+  }
+
+  Widget _controlsContainer(BuildContext context) {
+    return Visibility(
+        visible: showControls,
+        child: Container(
+          color: Colors.black45,
+          child: Row(children: [
+            IconButton(
+                onPressed: () => Navigator.pop(context),
+                icon: Icon(Icons.chevron_left)),
+            Spacer(),
+            IconButton(
+                onPressed: () {
+                  setState(() {
+                    isChatOnlyMode = true;
+                  });
+                },
+                icon: Icon(Icons.chat)),
+          ]),
+        ));
   }
 
   Widget _buildStacked(

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -174,7 +174,8 @@ class _ChannelScreenState extends State<ChannelScreen> {
           child: Row(children: [
             IconButton(
                 onPressed: () => Navigator.pop(context),
-                icon: Icon(Icons.chevron_left)),
+                icon: Icon(Icons.chevron_left),
+                color: Colors.white),
             Spacer(),
             IconButton(
                 onPressed: () {
@@ -182,7 +183,8 @@ class _ChannelScreenState extends State<ChannelScreen> {
                     isChatOnlyMode = true;
                   });
                 },
-                icon: Icon(Icons.chat)),
+                icon: Icon(Icons.chat),
+                color: Colors.white),
           ]),
         ));
   }

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -27,6 +27,17 @@ class _ChannelScreenState extends State<ChannelScreen> {
   _ChannelScreenState({required this.channel}) : super();
 
   @override
+  void initState() {
+    super.initState();
+
+    Future.delayed(const Duration(seconds: 5), () {
+      setState(() {
+        showControls = false;
+      });
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return BlocBuilder<ChannelBloc, ChannelState>(
         builder: (BuildContext context, ChannelState state) {

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -10,10 +10,19 @@ import 'package:glimesh_app/models.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:gettext_i18n/gettext_i18n.dart';
 
-class ChannelScreen extends StatelessWidget {
+class ChannelScreen extends StatefulWidget {
   final Channel channel;
 
-  ChannelScreen({Key? key, required this.channel}) : super(key: key);
+  const ChannelScreen({Key? key, required this.channel}) : super(key: key);
+
+  @override
+  State<ChannelScreen> createState() => _ChannelScreenState(channel: channel);
+}
+
+class _ChannelScreenState extends State<ChannelScreen> {
+  final Channel channel;
+
+  _ChannelScreenState({required this.channel}) : super();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -249,9 +249,10 @@ class _ChannelScreenState extends State<ChannelScreen> {
             )
           ],
         ),
-        body: Column(children: [
+        body: SafeArea(
+            child: Column(children: [
           Container(child: StreamTitle(channel: channel, allowMetadata: true)),
           Expanded(child: chatWidget),
-        ]));
+        ])));
   }
 }

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -238,7 +238,7 @@ class _ChannelScreenState extends State<ChannelScreen> {
           actions: [
             Padding(
               child: ElevatedButton(
-                child: Text(context.t("Exit Chat-Only Mode")),
+                child: Text(context.t("Exit")),
                 onPressed: () {
                   setState(() {
                     isChatOnlyMode = false;

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -77,20 +77,24 @@ class _ChannelScreenState extends State<ChannelScreen> {
         Widget chatWidget = Chat(channel: channel);
         Widget videoWidget = Stack(
           children: [
-            AspectRatio(
-              aspectRatio: 16 / 9,
-              child: FTLPlayer(channel: channel, edgeUrl: edgeRoute.url),
-            ),
             InkWell(
-              child: Padding(
-                padding: EdgeInsets.all(5),
-                child: Icon(
-                  Icons.chevron_left,
-                  color: Colors.white70,
-                ),
+              child: AspectRatio(
+                aspectRatio: 16 / 9,
+                child: FTLPlayer(channel: channel, edgeUrl: edgeRoute.url),
               ),
-              onTap: () => Navigator.pop(context),
-            )
+              onTap: () {
+                setState(() {
+                  showControls = !showControls;
+                });
+
+                Future.delayed(const Duration(seconds: 10), () {
+                  setState(() {
+                    showControls = false;
+                  });
+                });
+              },
+            ),
+            _controlsContainer(context),
           ],
         );
 

--- a/lib/screens/ChannelScreen.dart
+++ b/lib/screens/ChannelScreen.dart
@@ -21,6 +21,7 @@ class ChannelScreen extends StatefulWidget {
 
 class _ChannelScreenState extends State<ChannelScreen> {
   final Channel channel;
+  bool isChatOnlyMode = false;
 
   _ChannelScreenState({required this.channel}) : super();
 
@@ -91,6 +92,10 @@ class _ChannelScreenState extends State<ChannelScreen> {
             )
           ],
         );
+
+        if (isChatOnlyMode) {
+          return _buildChatOnlyMode(chatWidget);
+        }
 
         return Scaffold(
           // appBar here with 0 height just to make the background of the status bar black
@@ -187,5 +192,29 @@ class _ChannelScreenState extends State<ChannelScreen> {
         child: chatWidget,
       ),
     ]);
+  }
+
+  Widget _buildChatOnlyMode(Widget chatWidget) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(context.t("Chat-Only Mode")),
+          actions: [
+            Padding(
+              child: ElevatedButton(
+                child: Text(context.t("Exit Chat-Only Mode")),
+                onPressed: () {
+                  setState(() {
+                    isChatOnlyMode = false;
+                  });
+                },
+              ),
+              padding: EdgeInsets.all(8),
+            )
+          ],
+        ),
+        body: Column(children: [
+          Container(child: StreamTitle(channel: channel, allowMetadata: true)),
+          Expanded(child: chatWidget),
+        ]));
   }
 }


### PR DESCRIPTION
This PR closes #30 - adding a Chat Only Mode.

There's two parts to this PR:
- Adding a Controls part to the player, which lives at the top of the screen atop the player (see below). This is where the button to trigger chat-only mode lives, along with the navigation back button. It can be shown / hidden by tapping the video and will automatically hide after 10s when tapped. There's also a slight background on it to ensure the icons stay visible.

In the future, we can add other things like player settings if we get transcoding for selecting different resolutions / bitrates or a button to toggle audio-only mode.
![IMG_612828A54300-1](https://user-images.githubusercontent.com/16962286/167295539-47b85a19-ff06-4e62-9ef1-e6ab2523c2fa.jpeg)

- And then, of course, there's the actual Chat Only Mode, which is pretty much the Stacked layout we use for phones but just without the video player and with an App Bar that has an exit button to take the user back to the main channel page with video and all.
![IMG_087EF800E21D-1](https://user-images.githubusercontent.com/16962286/167295896-3d199e6d-094b-409e-af77-9e63befdf083.jpeg)