### PR TITLE
Chat Improvements

### DIFF
--- a/lib/blocs/repos/chat_messages_bloc.dart
+++ b/lib/blocs/repos/chat_messages_bloc.dart
@@ -116,6 +116,8 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
           .map((dynamic e) => ChatMessage(
               username: e['node']['user']['username'] as String,
               avatarUrl: e['node']['user']['avatarUrl'] as String,
+              isSystemMessage: e['node']['isFollowedMessage'] ||
+                  e['node']['isSubscriptionMessage'],
               tokens: _buildMessageTokensFromJson(e['node']['tokens']),
               metadata: _buildMessageMetadataFromJson(e['node']['metadata'])))
           .toList();
@@ -135,6 +137,8 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
         ChatMessage chatMessage = ChatMessage(
             username: data['user']['username'] as String,
             avatarUrl: data['user']['avatarUrl'] as String,
+            isSystemMessage: data['node']['isFollowedMessage'] ||
+                data['node']['isSubscriptionMessage'],
             tokens: _buildMessageTokensFromJson(data['tokens']),
             metadata: _buildMessageMetadataFromJson(data['metadata']));
 

--- a/lib/blocs/repos/chat_messages_bloc.dart
+++ b/lib/blocs/repos/chat_messages_bloc.dart
@@ -114,10 +114,10 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
 
       final List<ChatMessage> existingChatMessages = messages
           .map((dynamic e) => ChatMessage(
-                username: e['node']['user']['username'] as String,
-                avatarUrl: e['node']['user']['avatarUrl'] as String,
-                tokens: _buildMessageTokensFromJson(e['node']['tokens']),
-              ))
+              username: e['node']['user']['username'] as String,
+              avatarUrl: e['node']['user']['avatarUrl'] as String,
+              tokens: _buildMessageTokensFromJson(e['node']['tokens']),
+              metadata: _buildMessageMetadataFromJson(e['node']['metadata'])))
           .toList();
       chatMessages = existingChatMessages.reversed.toList();
 
@@ -133,10 +133,10 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
         dynamic data = event.data!['chatMessage'] as dynamic;
 
         ChatMessage chatMessage = ChatMessage(
-          username: data['user']['username'] as String,
-          avatarUrl: data['user']['avatarUrl'] as String,
-          tokens: _buildMessageTokensFromJson(data['tokens']),
-        );
+            username: data['user']['username'] as String,
+            avatarUrl: data['user']['avatarUrl'] as String,
+            tokens: _buildMessageTokensFromJson(data['tokens']),
+            metadata: _buildMessageMetadataFromJson(data['metadata']));
 
         // Send new chat messages as new events
         add(NewChatMessage(chatMessage: chatMessage));
@@ -169,5 +169,18 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
         .toList();
 
     return tokens;
+  }
+
+  MessageMetadata? _buildMessageMetadataFromJson(dynamic json) {
+    if (json == null) return null;
+
+    return MessageMetadata(
+      admin: json['admin'],
+      moderator: json['moderator'],
+      platformFounderSubscriber: json['platformFounderSubscriber'],
+      platformSupporterSubscriber: json['platformSupporterSubscriber'],
+      streamer: json['streamer'],
+      subscriber: json['subscriber'],
+    );
   }
 }

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -115,6 +115,8 @@ class ChatMessages extends StatelessWidget {
         child: Container(
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(5),
+            border:
+                message.isSystemMessage ? Border.all(color: Colors.cyan) : null,
             color: Theme.of(context).brightness == Brightness.dark
                 ? Color(0xFF0E1826).withOpacity(0.90)
                 : Colors.white.withOpacity(0.90),
@@ -125,7 +127,7 @@ class ChatMessages extends StatelessWidget {
               ..._buildUserBadges(message.metadata),
               _buildAvatar(message),
               TextSpan(
-                text: message.username + ": ",
+                text: message.username + (message.isSystemMessage ? "" : ": "),
                 style: TextStyle(
                     fontSize: 16, color: _getNameColour(message.metadata)),
               ),

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -122,9 +122,10 @@ class ChatMessages extends StatelessWidget {
           padding: EdgeInsets.all(10),
           child: Text.rich(
             TextSpan(children: [
+              ..._buildUserBadges(message.metadata),
               WidgetSpan(
                 child: Padding(
-                  padding: EdgeInsets.only(right: 10),
+                  padding: EdgeInsets.only(right: 5),
                   child: CircleAvatar(
                     radius: 10,
                     backgroundImage: NetworkImage(message.avatarUrl),
@@ -179,5 +180,38 @@ class ChatMessages extends StatelessWidget {
       image: CachedNetworkImageProvider(url),
       filterQuality: FilterQuality.medium,
     );
+  }
+
+  List<InlineSpan> _buildUserBadges(MessageMetadata? meta) {
+    if (meta == null) return List.empty();
+
+    var badges = <InlineSpan>[];
+
+    if (meta.admin) badges.add(_badge(Icons.verified_user, Colors.red));
+    if (meta.moderator)
+      badges.add(_badge(Icons.security, Colors.blue.shade700));
+    if (meta.streamer) badges.add(_badge(Icons.tv, Colors.blue));
+    if (meta.subscriber)
+      badges.add(_badge(Icons.emoji_events, Colors.purple.shade800));
+
+    return badges;
+  }
+
+  WidgetSpan _badge(IconData icon, Color color) {
+    return WidgetSpan(
+        child: Padding(
+      child: DecoratedBox(
+        child: Padding(
+            child: Icon(
+              icon,
+              size: 16,
+              color: Colors.white,
+            ),
+            padding: EdgeInsets.all(2)),
+        decoration:
+            BoxDecoration(color: color, borderRadius: BorderRadius.circular(5)),
+      ),
+      padding: EdgeInsets.only(right: 4),
+    ));
   }
 }

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -182,7 +182,7 @@ class ChatMessages extends StatelessWidget {
 
     var badges = <InlineSpan>[];
 
-    if (meta.admin) badges.add(_badge(Icons.verified_user, Colors.red));
+    if (meta.admin) badges.add(_badge(Icons.business, Colors.red));
     if (meta.moderator)
       badges.add(_badge(Icons.security, Colors.blue.shade700));
     if (meta.streamer) badges.add(_badge(Icons.tv, Colors.blue));

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -123,15 +123,7 @@ class ChatMessages extends StatelessWidget {
           child: Text.rich(
             TextSpan(children: [
               ..._buildUserBadges(message.metadata),
-              WidgetSpan(
-                child: Padding(
-                  padding: EdgeInsets.only(right: 5),
-                  child: CircleAvatar(
-                    radius: 10,
-                    backgroundImage: NetworkImage(message.avatarUrl),
-                  ),
-                ),
-              ),
+              _buildAvatar(message),
               TextSpan(
                 text: message.username + ": ",
                 style: TextStyle(
@@ -221,5 +213,40 @@ class ChatMessages extends StatelessWidget {
     if (meta.platformFounderSubscriber) return Colors.yellow.shade700;
 
     return null;
+  }
+
+  WidgetSpan _buildAvatar(ChatMessage message) {
+    if (message.metadata != null) {
+      if (message.metadata!.platformFounderSubscriber ||
+          message.metadata!.platformSupporterSubscriber) {
+        return WidgetSpan(
+          child: Padding(
+            padding: EdgeInsets.only(right: 5),
+            child: DecoratedBox(
+              child: Padding(
+                  child: CircleAvatar(
+                    radius: 9,
+                    backgroundImage: NetworkImage(message.avatarUrl),
+                  ),
+                  padding: EdgeInsets.all(1)),
+              decoration: ShapeDecoration(
+                  shape: CircleBorder(
+                      side:
+                          BorderSide(color: Colors.yellow.shade700, width: 1))),
+            ),
+          ),
+        );
+      }
+    }
+
+    return WidgetSpan(
+      child: Padding(
+        padding: EdgeInsets.only(right: 5),
+        child: CircleAvatar(
+          radius: 10,
+          backgroundImage: NetworkImage(message.avatarUrl),
+        ),
+      ),
+    );
   }
 }

--- a/lib/components/Chat.dart
+++ b/lib/components/Chat.dart
@@ -134,7 +134,8 @@ class ChatMessages extends StatelessWidget {
               ),
               TextSpan(
                 text: message.username + ": ",
-                style: TextStyle(fontSize: 16),
+                style: TextStyle(
+                    fontSize: 16, color: _getNameColour(message.metadata)),
               ),
               ..._buildTokens(message.tokens)
             ]),
@@ -213,5 +214,12 @@ class ChatMessages extends StatelessWidget {
       ),
       padding: EdgeInsets.only(right: 4),
     ));
+  }
+
+  Color? _getNameColour(MessageMetadata? meta) {
+    if (meta == null) return null;
+    if (meta.platformFounderSubscriber) return Colors.yellow.shade700;
+
+    return null;
   }
 }

--- a/lib/graphql/queries/chat.dart
+++ b/lib/graphql/queries/chat.dart
@@ -5,6 +5,8 @@ query GetSomeChatMessages($channelId: ID!) {
       edges {
         node {
           id
+		  isFollowedMessage
+		  isSubscriptionMessage
           tokens {
             type
             ...on EmoteToken {
@@ -34,6 +36,8 @@ query GetSomeChatMessages($channelId: ID!) {
 const String chatMessagesSubscription = r'''
 subscription ChatMessages($channelId: ID!) {
   chatMessage(channelId: $channelId) {
+	isFollowedMessage
+	isSubscriptionMessage
     tokens {
       type
       ... on EmoteToken {

--- a/lib/graphql/queries/chat.dart
+++ b/lib/graphql/queries/chat.dart
@@ -16,6 +16,14 @@ query GetSomeChatMessages($channelId: ID!) {
             username
             avatarUrl
           }
+		  metadata {
+			admin
+			moderator
+			platformFounderSubscriber
+			platformSupporterSubscriber
+			streamer
+			subscriber
+		  }
         }
       }
     }
@@ -37,6 +45,14 @@ subscription ChatMessages($channelId: ID!) {
       username
       avatarUrl
     }
+	metadata {
+	  admin
+	  moderator
+	  platformFounderSubscriber
+	  platformSupporterSubscriber
+	  streamer
+	  subscriber
+	}
   }
 }
 ''';

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -81,12 +81,14 @@ class ChatMessage {
     required this.avatarUrl,
     required this.tokens,
     this.metadata,
+    required this.isSystemMessage,
   });
 
   final String username;
   final String avatarUrl;
   final List<MessageToken> tokens;
   final MessageMetadata? metadata;
+  final bool isSystemMessage;
 }
 
 class Category {

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -57,16 +57,36 @@ class MessageToken {
   final String? src;
 }
 
+class MessageMetadata {
+  const MessageMetadata({
+    required this.admin,
+    required this.moderator,
+    required this.platformFounderSubscriber,
+    required this.platformSupporterSubscriber,
+    required this.streamer,
+    required this.subscriber,
+  });
+
+  final bool admin;
+  final bool moderator;
+  final bool platformFounderSubscriber;
+  final bool platformSupporterSubscriber;
+  final bool streamer;
+  final bool subscriber;
+}
+
 class ChatMessage {
   const ChatMessage({
     required this.username,
     required this.avatarUrl,
     required this.tokens,
+    this.metadata,
   });
 
   final String username;
   final String avatarUrl;
   final List<MessageToken> tokens;
+  final MessageMetadata? metadata;
 }
 
 class Category {


### PR DESCRIPTION
Doesn't close any issues, but with Glimesh/glimesh.tv#831 being merged, I decided to work on chat a bit.

What this PR adds:
- Badges before usernames for Admins, Moderators, Streamers and Channel Subs
- Yellow usernames for Gold Supporters
- The gold avatar ring for all Supporters
- Borders for Follow and Subscription messages
- Hides the colon between the name and the message when the message is a Follow or Sub message

The badge icons are inspired by MemoryLeakDeath's as-yet-unmerged PR where he's been working on the same thing for the site.

Here's some screenshots:

![screenshot1](https://user-images.githubusercontent.com/16962286/168440930-f3acf2f2-6e1d-4117-bbe4-59ba8ed6561f.png)
![screenshot2](https://user-images.githubusercontent.com/16962286/168440937-833dce35-274d-4c05-b954-8cea23c125ff.png)