### PR TITLE
Fix chat not showing new messages

### DIFF
--- a/lib/blocs/repos/chat_messages_bloc.dart
+++ b/lib/blocs/repos/chat_messages_bloc.dart
@@ -137,8 +137,8 @@ class ChatMessagesBloc extends Bloc<ChatMessagesEvent, ChatMessagesState> {
         ChatMessage chatMessage = ChatMessage(
             username: data['user']['username'] as String,
             avatarUrl: data['user']['avatarUrl'] as String,
-            isSystemMessage: data['node']['isFollowedMessage'] ||
-                data['node']['isSubscriptionMessage'],
+            isSystemMessage: data['isFollowedMessage'] ||
+                data['isSubscriptionMessage'],
             tokens: _buildMessageTokensFromJson(data['tokens']),
             metadata: _buildMessageMetadataFromJson(data['metadata']));
 


### PR DESCRIPTION
Copy / paste error led to trying to access `node` when it doesn't exist, somehow Flutter didn't print an error and just broke chat